### PR TITLE
Smart last pane/window selection

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -30,7 +30,8 @@ bind -T copy-mode-vi 'v' send -X begin-selection
 bind -T copy-mode-vi 'y' send -X copy-selection
 
 set-option -g prefix C-space
-bind C-space last-window
+bind-key C-Space run "tmux last-pane || tmux last-window || tmux display 'No last pane or window'"
+bind-key Enter   run "tmux last-window || tmux last-pane || tmux display 'No last window or pane'"
 
 # Start numbering at 1
 set -g base-index 1


### PR DESCRIPTION
Change tmux `C-Space` behavior to try to switch to the *last-pane* first
and *last-window* if only pane is open in that window.

Similar way `Enter` try to switch to the *last-window* first and if only one
window is open try to switch to the *last-pane*.