### PR TITLE
Must quote/escape backslashes in newer tmux versions

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -38,7 +38,7 @@ set -g base-index 1
 bind v split-window -h -c "#{pane_current_path}"
 
 # Unprefixed {{{
-  bind -n C-M-\ setw synchronize-panes
+  bind -n 'C-M-\' setw synchronize-panes
   bind -n C-M-c send-keys -R \; clear-history
 
   bind-key -n C-M-h select-pane -L


### PR DESCRIPTION
hi luan

Received the following error when installing: `/Users/jwal/.tmux.conf:41: unknown key: C-M- setw`

Appears that newer versions of `tmux` require backslashes to be either quoted or escaped.

Using latest version of `tmux` available via Homebrew:

```
tmux: stable 3.0a (bottled), HEAD
Terminal multiplexer
https://tmux.github.io/
/usr/local/Cellar/tmux/3.0a (9 files, 802.6KB) *
  Poured from bottle on 2019-12-10 at 14:13:41
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/tmux.rb
```

thx