### PR TITLE
Escape backslash character in tmux config

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -38,7 +38,7 @@ set -g base-index 1
 bind v split-window -h -c "#{pane_current_path}"
 
 # Unprefixed {{{
-  bind -n C-M-\ setw synchronize-panes
+  bind -n C-M-\\ setw synchronize-panes
   bind -n C-M-c send-keys -R \; clear-history
 
   bind-key -n C-M-h select-pane -L


### PR DESCRIPTION
Tmux was complaining that `C-M-` was not a key. The issue was an unescaped `\` in the config. Escaping this removes the issue. 

Many thanks

James & Gareth