### PR TITLE
Reset window resizing to smallest tty

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -89,6 +89,7 @@ unbind -T copy-mode    MouseDragEnd1Pane
   set-option -g visual-bell off
   set-option -g visual-silence off
   set-window-option -g monitor-activity off
+  set-window-option -g window-size smallest
   set-option -g bell-action none
 
   # messaging


### PR DESCRIPTION
Newer versions of tmux (3.x+) introduced a new default value which resizes tmux windows to whichever tty is the latest to interact with it. This unfortunately breaks our normal, preferred behavior which is to resize to whatever the smallest attached tty is.

This PR overrides the new global default to use the smallest tty instead now.