### PR TITLE
Use OSX-Compatible Default Terminal Setting

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -11,7 +11,7 @@ set -g @open 'O'
 set -g @open-editor 'C-o'
 set -g @open-S 'https://www.google.com/search?q='
 
-set -g default-terminal "tmux-256color"
+set -g default-terminal "xterm-256color"
 
 set -g set-clipboard off
 


### PR DESCRIPTION
Without a change similar to this, the default terminal translates backspace to space