### PR TITLE
🧑‍💻 dx(tmux.conf): Remove extra TERM setting

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -15,7 +15,6 @@ set -g @open-editor 'C-o'
 set -g @open-S 'https://www.google.com/search?q='
 
 set -g default-terminal "xterm-256color"
-set -g default-terminal "xterm-kitty"
 
 set -g set-clipboard off
 


### PR DESCRIPTION
- with this setting, I am getting errors when opening a new terminal

```
warning: Could not set up terminal.
warning: TERM environment variable set to 'xterm-kitty'.
warning: Check that this terminal type is supported on this system.
warning: Using fallback terminal type 'xterm-256color'.
```
